### PR TITLE
Fix incorrect ws2811 high speed timing & tolerance

### DIFF
--- a/src/AsyncRgbLedAnalyzerSettings.cpp
+++ b/src/AsyncRgbLedAnalyzerSettings.cpp
@@ -71,8 +71,8 @@ void AsyncRgbLedAnalyzerSettings::InitControllerData()
             true,
             {
                 // high-speed times
-                {{175_ns, 250_ns, 325_ns}, {925_ns, 1000_ns, 1075_ns}},      // 0-bit times
-                {{525_ns, 600_ns, 675_ns}, {1225_ns, 1300_ns, 1375_ns}}      // 1-bit times
+                {{100_ns, 250_ns, 400_ns}, {850_ns, 1000_ns, 1150_ns}},      // 0-bit times
+                {{450_ns, 600_ns, 750_ns}, {500_ns, 650_ns, 800_ns}}      // 1-bit times
             },
             LAYOUT_RGB
         },


### PR DESCRIPTION
The high speed timing for WS2811 1 bit low was not correctly half of the low speed timing.  

After addressing this issue, the analyser still failed to correctly interpret my captured data due to the tolerances.  The datasheet or the original ws2811 drivers is ambiguous on whether the tolerances should also be divided for high speed mode.  The behavior of the driver as well as the datasheet of the similar 2812 part (800mhz, +-150ns tolerance) seem to indicate that the tolerance should remain +- 150ns.

Changing the tolerances as suggested in #2 results in correct analysis.

I've attached a sample capture taken using an ESP32 controller running the FastLED library on WS2811 800MHz mode  #LEDs
[ws2811_on_esp32_fastled.zip](https://github.com/saleae/async-rgb-led-analyzer/files/5287512/ws2811_on_esp32_fastled.zip)


 