### PR TITLE
useframev2

### DIFF
--- a/src/AsyncRgbLedAnalyzer.cpp
+++ b/src/AsyncRgbLedAnalyzer.cpp
@@ -10,6 +10,7 @@
 AsyncRgbLedAnalyzer::AsyncRgbLedAnalyzer() : Analyzer2(), mSettings( new AsyncRgbLedAnalyzerSettings )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 AsyncRgbLedAnalyzer::~AsyncRgbLedAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.